### PR TITLE
Fixed unit test compilation - added explicit .get to nullables

### DIFF
--- a/source/dutils/validation/validate.d
+++ b/source/dutils/validation/validate.d
@@ -54,7 +54,7 @@ void validate(T)(ref T object, string pathPrefix) {
             auto path = pathPrefix.length > 0 ? pathPrefix ~ "." ~ member : member;
             auto result = attribute.getError(value, path);
             if (!result.isNull) {
-              errors ~= result;
+              errors ~= result.get;
             }
           }
         }
@@ -84,7 +84,7 @@ void validate(T)(ref T object, string pathPrefix) {
             auto path = pathPrefix.length > 0 ? pathPrefix ~ "." ~ member : member;
             auto result = attribute.getError(__traits(getMember, object, member), path);
             if (!result.isNull) {
-              errors ~= result;
+              errors ~= result.get;
             }
           }
         }


### PR DESCRIPTION
> **Note:** I know that this project has not been updated for some time, but still I would kindly ask the maintainers to merge this PR and release the new tag. I am trying to use `dutils-message`, as it seems the only way to go for RabbitMQ in conjunction with `vibe.d` (I tried hunt-amqp, but even importing it along vibe.d makes the application crash on startup). However, because the error fixed by this PR it will not build without cloning/forking/fixing things manually. I hope that making a new tag is just a few minutes of your precious time to help a lot people trying to – for example – use RabbitMQ in D. Thank you in advance! :)

Some time ago in Phobos Nullable's `alias this` to underlying object was removed – therefore the following behavior became illegal:

```d
auto x = 5.nullable;
int y = x;
```

Instead, the `.get` is now obligatory:

```d
int y = x.get;
```

Those `.get`s have been added in a few places.